### PR TITLE
Add (all-keys-in) validation function.

### DIFF
--- a/src/clojure/validateur/validation.clj
+++ b/src/clojure/validateur/validation.clj
@@ -194,7 +194,7 @@ functions, validation results are returned as values."}
    Used in conjunction with validation-set:
 
    (validation-set
-     (all-keys-in #{:foo :bar :baz}))"
+     (all-keys-in #{:church :turing :gödel}))"
   [allowed-keys & {:keys [unknown-message]
                    :or {unknown-message "unknown key"}}]
   {:pre [(set? allowed-keys)]}

--- a/test/validateur/test/validation_test.clj
+++ b/test/validateur/test/validation_test.clj
@@ -240,16 +240,16 @@
 ;;
 
 (deftest test-allowed-keys-validator
-  (let [allowed-keys #{:foo "bar" 123}
+  (let [allowed-keys #{:turing "von neumann" 1954}
         v (all-keys-in allowed-keys)]
     (is (fn? v))
-    (is (= [true {}] (v {:foo "foo"})))
-    (is (= [true {}] (v {"bar" :bar})))
-    (is (= [true {}] (v {123 123})))
-    (is (= [true {}] (v {:foo 1, "bar" 2, 123 456})))
-    (is (= [false {:spam #{"unknown key"}}] (v {:spam "eggs"})))
-    (is (= [false {789 #{"unknown key"}}] (v {789 3.14})))
-    (is (= [false {"biz" #{"unknown key"}}] (v {"biz" "baz"})))))
+    (is (= [true {}] (v {:turing "top"})))
+    (is (= [true {}] (v {"von neumann" :von-neumann})))
+    (is (= [true {}] (v {1954 1954})))
+    (is (= [true {}] (v {:turing 1, "von neumann" 2, 1954 4591})))
+    (is (= [false {:babbage #{"unknown key"}}] (v {:babbage "lovelace"})))
+    (is (= [false {4591 #{"unknown key"}}] (v {4591 6.28})))
+    (is (= [false {"church" #{"unknown key"}}] (v {"church" "none"})))))
 
 ;;
 ;; inclusion-of


### PR DESCRIPTION
I wrote the (all-keys-in) validation function and have used it in several projects; it seems general enough that it may be useful to other folks. The function just ensures that all keys in the map being validated are drawn from a set of allowed keys.
