### PR TITLE
change inclusion-of with :allow-nil set to true

### DIFF
--- a/src/clojure/validateur/validation.clj
+++ b/src/clojure/validateur/validation.clj
@@ -243,8 +243,10 @@ functions, validation results are returned as values."}
                           (str message (clojure.string/join ", " in))))]
     (fn [m]
       (let [v (f m attribute)]
-        (if (and (nil? v) (not allow-nil))
-          [false {attribute #{(blank-msg-fn m)}}]
+        (if (nil? v) 
+          (if allow-nil
+            [true {}]
+            [false {attribute #{(blank-msg-fn m)}}])
           (if (in v)
             [true {}]
             [false {attribute #{(msg-fn m)}}]))))))

--- a/test/validateur/test/validation_test.clj
+++ b/test/validateur/test/validation_test.clj
@@ -313,6 +313,15 @@
                              [#{"trance", "dnb"}]]}}]
            (v { :genre "1" })))))
 
+(deftest test-inclusion-validation-with-allow-nil-true
+  (let [v (inclusion-of :genre :in #{"trance" "dnb"} :allow-nil true)]
+    (is (fn? v))
+    (is (= [true {}] (v {:genre "trance"})))
+    (is (= [true {}] (v {:genre "dnb"})))
+    (is (= [false {:genre #{"must be one of: trance, dnb"}}] (v {:genre "hiphop"})))
+    (is (= [true {}] (v {:category "trance"})))
+    (is (= [true {}] (v {:genre nil})))))
+
 ;;
 ;; exclusion-of
 ;;


### PR DESCRIPTION
Before this change, the option :allow-nil did not impact the set of valid maps.
This change allows inclusion-of with allow-nil set to true to pass maps with the key is missing the value is nil to be valid.
