### PR TITLE
Corrected logic in blank/nil validations.

### DIFF
--- a/src/clojure/validateur/validation.clj
+++ b/src/clojure/validateur/validation.clj
@@ -25,12 +25,12 @@
 (defn- not-allowed-to-be-blank?
   [v ^Boolean allow-nil ^Boolean allow-blank]
   (or (and (nil? v)                  (not allow-nil))
-      (and (clojure.string/blank? v) (not allow-blank))))
+      (and (not (nil? v)) (clojure.string/blank? v) (not allow-blank))))
 
 (defn- allowed-to-be-blank?
   [v ^Boolean allow-nil ^Boolean allow-blank]
   (or (and (nil? v)                  allow-nil)
-      (and (clojure.string/blank? v) allow-blank)))
+      (and (not (nil? v)) (clojure.string/blank? v) allow-blank)))
 
 
 (defn- equal-length-of


### PR DESCRIPTION
Corrected the logic in the allowed-to-be-blank functions to properly allow nil values when allow-nil is true, but allow-blank is false. Previously, both allow-blank and allow-nil had to be set to true to allow nil values due to clojure's blank? function returning true for nil.
