### PR TITLE
Add ClojureScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Validateur, a Clojure Validation Library
+# Validateur, a Clojure(Script) Validation Library
 
-Validateur is a [Clojure validation library](http://clojurevalidations.info) inspired by Ruby's ActiveModel. Validateur is functional: validators are
+Validateur is a [Clojure(Script) validation library](http://clojurevalidations.info) inspired by Ruby's ActiveModel. Validateur is functional: validators are
 functions, validation sets are higher-order functions, validation results are returned as values.
 
 
 ## Supported Clojure versions
 
-Validateur requires Clojure 1.4+.
+Validateur requires Clojure 1.4+/ClojureScript 0.0-2138+.
 
 
 
@@ -45,7 +45,7 @@ Our test suite has usage examples for each validator, built-in validation functi
 Validateur uses [Leiningen 2](https://github.com/technomancy/leiningen/blob/master/doc/TUTORIAL.md). Make
 sure you have it installed and then run tests against all supported Clojure versions using
 
-    lein2 all test
+    lein2 do clean, cljx once, all test, cljsbuild test
 
 Then create a branch and make your changes on it. Once you are done with your changes and all
 tests pass, submit a pull request on Github.
@@ -59,4 +59,3 @@ Distributed under the Eclipse Public License, the same as Clojure.
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/michaelklishin/validateur/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/project.clj
+++ b/project.clj
@@ -5,11 +5,35 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure  "1.5.1"]
                  [clojurewerkz/support "0.20.0"]]
+  :jar-exclusions [#"\.cljx"]
   :profiles {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}
              :master {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}
-             :dev {:plugins [[codox "0.6.4"]]
-                   :codox {:sources ["src/clojure"]
+             :dev {:dependencies [[org.clojure/clojurescript "0.0-2138"]]
+                   :plugins [[codox "0.6.4"]
+                             [com.keminglabs/cljx "0.3.2"]
+                             [lein-cljsbuild "1.0.1"]
+                             [com.cemerick/clojurescript.test "0.2.1"]]
+                   :cljx {:builds [{:source-paths ["src/cljx"]
+                                    :output-path "target/classes"
+                                    :rules :clj}
+                                   {:source-paths ["src/cljx"]
+                                    :output-path "target/classes"
+                                    :rules :cljs}
+                                   {:source-paths ["test"]
+                                    :output-path "target/test-classes"
+                                    :rules :clj}
+                                   {:source-paths ["test"]
+                                    :output-path "target/test-classes"
+                                    :rules :cljs}]}
+                   :cljsbuild {:crossovers [clojurewerkz.support.core]
+                               :test-commands {"phantom" ["phantomjs" :runner "target/testable.js"]}
+                               :builds [{:source-paths ["target/classes" "target/test-classes"]
+                                         :compiler {:output-to "target/testable.js"
+                                                    :libs [""]
+                                                    :source-map "target/testable.js.map"
+                                                    :optimizations :advanced}}]}
+                   :codox {:sources ["src/cljx"]
                            :output-dir "doc/api"}}}
   :aliases  {"all" ["with-profile" "+dev:+1.4:+1.6:+master"]}
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
@@ -18,6 +42,7 @@
                  "sonatype-snapshots" {:url "http://oss.sonatype.org/content/repositories/snapshots"
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
-  :source-paths   ["src/clojure"]
+  :source-paths ["src/cljx" "target/classes"]
+  :test-paths ["target/test-classes"]
   :test-selectors {:focus :focus}
   :codox {:only [validateur.validation]})

--- a/src/cljx/validateur/validation.cljx
+++ b/src/cljx/validateur/validation.cljx
@@ -4,7 +4,7 @@
    functions, validation results are returned as values."
   (:require clojure.string
             [clojure.set :as cs]
-            [clojurewerkz.support.core :refer [assoc-with]]))
+            [clojurewerkz.support.core :as sp]))
 
 
 ;;
@@ -81,7 +81,7 @@
         [(empty? errors) errors]))))
 
 (def ^{:private true}
-  assoc-with-union (partial assoc-with cs/union))
+  assoc-with-union (partial sp/assoc-with cs/union))
 
 (defn numericality-of
   "Returns a function that, when given a map, will validate that the value of the attribute in that map is numerical.
@@ -243,7 +243,7 @@
                           (str message (clojure.string/join ", " in))))]
     (fn [m]
       (let [v (f m attribute)]
-        (if (nil? v) 
+        (if (nil? v)
           (if allow-nil
             [true {}]
             [false {attribute #{(blank-msg-fn m)}}])


### PR DESCRIPTION
I experimented with replacing valip with validateur in [modern-cljs guide](https://github.com/magomimmo/modern-cljs/blob/master/doc/tutorial-13.md#the-server-side-validation) and everything went fine.

So I added testing under ClojureScript. Hope you like the idea. Feedback is highly appreciated.

P.S. There is one failing test at the moment under cljs and I'm not sure how to properly fix it.

``` clojure
FAIL in (test-format-of-validator-with-optional-message-fn) (:)
expected: (= [false {:id #{[:format {:id "123-abc"} :id ["abc-\\d\\d\\d"]]}}] (v {:id "123-abc"}))
  actual: (not (= [false {:id #{[:format {:id "123-abc"} :id ["abc-\\d\\d\\d"]]}}] [false {:id #{[:format {:id "123-abc"} :id ("/abc-\\d\\d\\d/")]}}]))
```
