### PR TITLE
Remove clojurewerkz/support dependency.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,7 @@
   :license { :name "Eclipse Public License" }
   :url "http://clojurevalidations.info"
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure  "1.5.1"]
-                 [clojurewerkz/support "0.20.0"]]
+  :dependencies [[org.clojure/clojure  "1.5.1"]]
   :jar-exclusions [#"\.cljx"]
   :profiles {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}

--- a/src/cljx/validateur/validation.cljx
+++ b/src/cljx/validateur/validation.cljx
@@ -12,8 +12,7 @@
    Validateur is functional: validators are functions, validation sets are higher-order
    functions, validation results are returned as values."
   (:require clojure.string
-            [clojure.set :as cs]
-            [clojurewerkz.support.core :as sp]))
+            [clojure.set :as cs]))
 
 
 ;;
@@ -89,8 +88,9 @@
             errors (if res {} {attribute #{msg}})]
         [(empty? errors) errors]))))
 
-(def ^{:private true}
-  assoc-with-union (partial sp/assoc-with cs/union))
+(defn ^{:private true} assoc-with-union
+  [m k v]
+  (assoc m k (apply cs/union [(get m k) v])))
 
 (defn numericality-of
   "Returns a function that, when given a map, will validate that the value of the attribute in that map is numerical.


### PR DESCRIPTION
This change is necessary due to the removal of crossovers from
lein-cljsbuild which is needed for clojurewerkz/support.core to work on
cljs. This also makes it easier for people to use it since they can't
forget the special build requirements (See #18).
Furthermore, validateur only uses one tiny function of the entire core
library which and pulls in an entire jar for that.
It also reduces the generated javascript code.

This patch reduces complexity and the library size as well as makes it
easier to use validateur.
