### PR TITLE
Predicate validation

### DIFF
--- a/src/cljx/validateur/validation.cljx
+++ b/src/cljx/validateur/validation.cljx
@@ -401,7 +401,7 @@
 
 
 
-(defn validate [attribute predicate & {:keys [message] :or {message "is invalid"}}]
+(defn validate-with-predicate [attribute predicate & {:keys [message] :or {message "is invalid"}}]
   "Returns a function that, when given a map, will validate that the predicate returns
   true when given the map.
   
@@ -413,7 +413,7 @@
   
   (use 'validateur.validation)
   
-  (validate :name #(contains? % :name))"
+  (validate-with-predicate :name #(contains? % :name))"
   (fn [m]
     (if (predicate m)
       [true {}]

--- a/test/validateur/test/validation_test.cljx
+++ b/test/validateur/test/validation_test.cljx
@@ -596,23 +596,23 @@
            (v {:id "123-abc"})))))
 
 ;;
-;; validate
+;; validate-with-predicate
 ;;
 
-(deftest test-validate-predicate-returns-false
-  (let [v (vr/validate :id (constantly false))]
+(deftest test-validate-with-predicate-predicate-returns-false
+  (let [v (vr/validate-with-predicate :id (constantly false))]
     (is (fn? v))
     (is (= [false {:id #{"is invalid"}}]
            (v {})))))
 
-(deftest test-validate-predicate-returns-true
-  (let [v (vr/validate :id (constantly true))]
+(deftest test-validate-with-predicate-predicate-returns-true
+  (let [v (vr/validate-with-predicate :id (constantly true))]
     (is (fn? v))
     (is (= [true {}]
            (v {})))))
 
-(deftest test-validate-predicate-returns-false-with-custom-message
-  (let [v (vr/validate :id (constantly false) :message "test")]
+(deftest test-validate-with-predicate-predicate-returns-false-with-custom-message
+  (let [v (vr/validate-with-predicate :id (constantly false) :message "test")]
     (is (= [false {:id #{"test"}}]
            (v {})))))
 


### PR DESCRIPTION
Curious how you feel about introducing a validator that accepts arbitrary predicate functions.  I find that I already have useful functions that return `true` or `false` but validateur expects something of the form `[valid? {field #{msg}}]`.

One potential solution:

``` clojure
(defn validate [attribute predicate & {:keys [message] :or {message "is invalid"}}]
  (fn [m]
    (if (predicate m)
      [true {}]
      [false {attribute #{message}}])))
```

Example usage:

``` clojure
(validate :email unique-email? :message "is already taken")
```

<hr>

Similarly it would be nice to be able to apply validators selectively:

``` clojure
(presence-of :password :when new-user?)
```

As it is currently, I believe the `:when predicate` would have to be added separately to each validator.  Perhaps some of the `:message`/`:message-fn` (and perhaps `:when`) handling could be extracted into something more reusable.

Alternatively, I'm currently using:

``` clojure
(defn validate-when [predicate validator]
  (fn [m]
    (if (predicate m)
      (validator m)
      [true {}])))
```

Example usage:

``` clojure
(validate-when new-user? (presence-of :password))
```

<hr>

I'd be happy to submit a pull request if any of this is something you're interested in including.
