### PR TITLE
Nested Validation Sets

### DIFF
--- a/src/cljx/validateur/validation.cljx
+++ b/src/cljx/validateur/validation.cljx
@@ -452,6 +452,24 @@
           [true {}]
           [false {attr #{message}}])))))
 
+
+(letfn [(collectify [attr]
+          (if (sequential? attr) attr [attr]))]
+  (defn nested
+    "Takes an attribute (either a single key or a vector of keys) and a
+  validation set, and returns a function that will apply the supplied
+  validation set to the inner value located at `attr`."
+    [attr vset]
+    (let [f (if (vector? attr) get-in get)]
+      (fn [m]
+        (let [subm (f m attr)]
+          (->> (for [[k message] (vset subm)
+                     :let [k (into (collectify attr)
+                                   (collectify k))]]
+                 [k message])
+               (into {})))))))
+
+
 (defn validate-with-predicate
   "Returns a function that, when given a map, will validate that the predicate returns
   true when given the map.

--- a/test/validateur/test/validation_test.cljx
+++ b/test/validateur/test/validation_test.cljx
@@ -669,6 +669,26 @@
     (is (= [true {}]
            (v {:x 12})))))
 
+;; nested
+
+(deftest test-nested
+  (let [v (vr/nested :user (vr/validation-set
+                            (vr/presence-of :name)
+                            (vr/presence-of :age)))
+        extra-nested (vr/nested [:user :profile]
+                                (vr/validation-set
+                                 (vr/presence-of :age)
+                                 (vr/presence-of [:birthday :year])))]
+    (is (fn? v))
+    (is (= {[:user :age] #{"can't be blank"}
+            [:user :name] #{"can't be blank"}}
+           (v {})))
+    (is (= {[:user :age] #{"can't be blank"}}
+           (v {:user {:name "name"}})))
+    (is (= {} (extra-nested {:user {:profile {:age 10
+                                              :birthday {:year 2004}}}})))
+    (is (= {[:user :profile :birthday :year] #{"can't be blank"}}
+           (extra-nested {:user {:profile {:age 10}}})))))
 ;;
 ;; validate-with-predicate
 ;;


### PR DESCRIPTION
I'm stacking this on top of the changes for #33, so that the merge stays clean; once that branch is merged the line count here will drop down.

`nested` allows the user to write more granular validations, then compose them up into larger, full-map validations. Let me know what you think!
