### PR TITLE
Fix bug whereby validity-of ignored first validator

### DIFF
--- a/src/validateur/validation.cljc
+++ b/src/validateur/validation.cljc
@@ -565,7 +565,7 @@
     (vr/presence-of :name)
     (vr/format-of :name :format #\"\\p{Alpha}+\")
     (vr/inclusion-of :status :in #{:active :inactive}))"
-  [attr validator & validators]
+  [attr & validators]
   (let [get-fn (if (vector? attr) get-in get)]
     (fn [m]
       (let [nested (get-fn m attr)]

--- a/test/validateur/test/validation_test.cljc
+++ b/test/validateur/test/validation_test.cljc
@@ -760,7 +760,6 @@
   (let [v (vr/validation-set
             (vr/presence-of :person)
             (vr/validity-of :person
-              (vr/presence-of :name)
               (vr/format-of :name :format #"[A-Za-zł]+")
               (vr/inclusion-of :status :in #{:active :inactive})))]
     (is (= {:person #{"can't be blank"}
@@ -781,7 +780,6 @@
   (let [v (vr/validation-set
             (vr/presence-of :person)
             (vr/validity-of :person
-              (vr/presence-of :name)
               (vr/format-of :name :format #"[A-Za-zł]+")
               (vr/inclusion-of :status :in #{:active :inactive})))]
     (is (= {} (v {:person {:name "Michał" :status :active}})))))


### PR DESCRIPTION
The tests were passing, because format-of performs its own implicit
presence check (unless explicitly suppressed), so

  (vr/validity-of :person
    (vr/presence-of :name)
    (vr/format-of :name :format …)
    …)

worked as expected without ever calling the presence-of validator.