### PR TITLE
Fix format validator

### DIFF
--- a/src/validateur/validation.cljc
+++ b/src/validateur/validation.cljc
@@ -369,7 +369,7 @@
         (if (not-allowed-to-be-blank? v allow-nil allow-blank)
           [false {attribute #{(msg-fn :blank m)}}]
           (if (or (allowed-to-be-blank? v allow-nil allow-blank)
-                  (re-find format v))
+                  (re-matches format v))
             [true {}]
             [false {attribute #{(msg-fn :format m)}}]))))))
 


### PR DESCRIPTION
Not sure why `re-find` is used to check format. 
It even doesn't work with the example from the docstring.
Just take a look:

```
(re-find #"[a-zA-Z0-9_]+" "foo#bar!!") => "foo"
(re-matches #"[a-zA-Z0-9_]+" "foo#bar!!") => nil
```